### PR TITLE
✨ [Auth] 인증 타입 및 정보 관리 기능 추가

### DIFF
--- a/src/domain/auth/auth_info/auth_info.py
+++ b/src/domain/auth/auth_info/auth_info.py
@@ -1,7 +1,9 @@
+from abc import abstractmethod
 from dataclasses import dataclass
 from uuid import UUID
 
-from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum
+from domain.auth.auth_info.exceptions import InvalidAuthTypeError
+from domain.auth.auth_info.value_objects import AuthType
 from domain.base.aggregate import Aggregate
 
 
@@ -10,8 +12,16 @@ class AuthInfo(Aggregate):
     user_id: UUID
     auth_type: AuthType
 
+    def __post_init__(self) -> None:
+        if not self.validate_auth_type():
+            raise InvalidAuthTypeError(self.auth_type)
+
+    @abstractmethod
+    def validate_auth_type(self) -> bool:
+        raise NotImplementedError
+
     def is_google_auth(self) -> bool:
-        return self.auth_type.value == AuthTypeEnum.GOOGLE
+        return self.auth_type.is_google()
 
     def is_local_auth(self) -> bool:
-        return self.auth_type.value == AuthTypeEnum.LOCAL
+        return self.auth_type.is_local()

--- a/src/domain/auth/auth_info/auth_info.py
+++ b/src/domain/auth/auth_info/auth_info.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum
+from domain.base.aggregate import Aggregate
+
+
+@dataclass(frozen=True, kw_only=True)
+class AuthInfo(Aggregate):
+    user_id: UUID
+    auth_type: AuthType
+
+    def is_google_auth(self) -> bool:
+        return self.auth_type.value == AuthTypeEnum.GOOGLE
+
+    def is_local_auth(self) -> bool:
+        return self.auth_type.value == AuthTypeEnum.LOCAL

--- a/src/domain/auth/auth_info/auth_info.py
+++ b/src/domain/auth/auth_info/auth_info.py
@@ -9,19 +9,50 @@ from domain.base.aggregate import Aggregate
 
 @dataclass(frozen=True, kw_only=True)
 class AuthInfo(Aggregate):
+    """
+    인증 정보의 공통 애그리거트 루트.
+
+    사용자 ID와 인증 방식을 캡슐화하며,
+    하위 클래스에서 구체 인증 방식별 유효성을 보장한다.
+    """
+
     user_id: UUID
     auth_type: AuthType
 
     def __post_init__(self) -> None:
+        """
+        인스턴스 생성 시 인증 타입의 유효성을 검증한다.
+
+        Raises:
+            InvalidAuthTypeError: auth_type이 하위 클래스에서 요구하는 값과 일치하지 않을 때 발생.
+        """
         if not self.validate_auth_type():
             raise InvalidAuthTypeError(self.auth_type)
 
     @abstractmethod
     def validate_auth_type(self) -> bool:
+        """
+        하위 클래스에서 인증 타입의 유효성을 검증하도록 강제한다.
+
+        Returns:
+            bool: 유효하면 True, 아니면 False.
+        """
         raise NotImplementedError
 
     def is_google_auth(self) -> bool:
+        """
+        현재 인증 타입이 Google OAuth인지 확인한다.
+
+        Returns:
+            bool: Google OAuth이면 True.
+        """
         return self.auth_type.is_google()
 
     def is_local_auth(self) -> bool:
+        """
+        현재 인증 타입이 Local 인증인지 확인한다.
+
+        Returns:
+            bool: Local 인증이면 True.
+        """
         return self.auth_type.is_local()

--- a/src/domain/auth/auth_info/exceptions.py
+++ b/src/domain/auth/auth_info/exceptions.py
@@ -1,0 +1,6 @@
+from domain.auth.auth_info.value_objects import AuthType
+
+
+class InvalidAuthTypeError(Exception):
+    def __init__(self, auth_type: AuthType) -> None:
+        super().__init__(f"Invalid auth type: {auth_type.value.value}")

--- a/src/domain/auth/auth_info/exceptions.py
+++ b/src/domain/auth/auth_info/exceptions.py
@@ -2,5 +2,16 @@ from domain.auth.auth_info.value_objects import AuthType
 
 
 class InvalidAuthTypeError(Exception):
+    """잘못된 인증 타입이 사용되었을 때 발생하는 예외.
+
+    Attributes:
+        auth_type (AuthType): 잘못 주입된 인증 타입 값.
+    """
+
     def __init__(self, auth_type: AuthType) -> None:
+        """InvalidAuthTypeError를 생성한다.
+
+        Args:
+            auth_type (AuthType): 잘못 주입된 인증 타입 값.
+        """
         super().__init__(f"Invalid auth type: {auth_type.value.value}")

--- a/src/domain/auth/auth_info/value_objects.py
+++ b/src/domain/auth/auth_info/value_objects.py
@@ -9,7 +9,7 @@ class AuthTypeEnum(Enum):
     GOOGLE = "GOOGLE"
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True)
 class AuthType(ValueObject[AuthTypeEnum]):
     value: AuthTypeEnum = field(default=AuthTypeEnum.LOCAL)
 

--- a/src/domain/auth/auth_info/value_objects.py
+++ b/src/domain/auth/auth_info/value_objects.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, field
+from enum import Enum
+
+from domain.base.value_object import ValueObject
+
+
+class AuthTypeEnum(Enum):
+    LOCAL = "LOCAL"
+    GOOGLE = "GOOGLE"
+
+
+@dataclass(frozen=True, kw_only=True)
+class AuthType(ValueObject[AuthTypeEnum]):
+    value: AuthTypeEnum = field(default=AuthTypeEnum.LOCAL)
+
+    def is_google(self) -> bool:
+        return self.value == AuthTypeEnum.GOOGLE
+
+    def is_local(self) -> bool:
+        return self.value == AuthTypeEnum.LOCAL

--- a/src/domain/auth/auth_info/value_objects.py
+++ b/src/domain/auth/auth_info/value_objects.py
@@ -5,16 +5,39 @@ from domain.base.value_object import ValueObject
 
 
 class AuthTypeEnum(Enum):
+    """인증 방식의 종류를 나타내는 열거형.
+
+    Values:
+        LOCAL: 로컬 계정 기반 인증.
+        GOOGLE: 구글 OAuth 기반 인증.
+    """
+
     LOCAL = "LOCAL"
     GOOGLE = "GOOGLE"
 
 
 @dataclass(frozen=True)
 class AuthType(ValueObject[AuthTypeEnum]):
+    """인증 방식 타입을 캡슐화하는 값 객체(Value Object).
+
+    Attributes:
+        value (AuthTypeEnum): 현재 인증 방식의 열거형 값.
+    """
+
     value: AuthTypeEnum = field(default=AuthTypeEnum.LOCAL)
 
     def is_google(self) -> bool:
+        """현재 인증 방식이 Google OAuth인지 확인한다.
+
+        Returns:
+            bool: Google OAuth이면 True, 아니면 False.
+        """
         return self.value == AuthTypeEnum.GOOGLE
 
     def is_local(self) -> bool:
+        """현재 인증 방식이 로컬 인증인지 확인한다.
+
+        Returns:
+            bool: 로컬 인증이면 True, 아니면 False.
+        """
         return self.value == AuthTypeEnum.LOCAL

--- a/tests/unit/domain/auth/auth_info/test_auth_info.py
+++ b/tests/unit/domain/auth/auth_info/test_auth_info.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+import pytest
+
+from domain.auth.auth_info.auth_info import AuthInfo
+from domain.auth.auth_info.exceptions import InvalidAuthTypeError
+from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum
+from shared_kernel.time.time_provider import TimeProvider
+
+
+@dataclass(frozen=True, kw_only=True)
+class GoogleOAuthInfo(AuthInfo):
+    auth_type: AuthType = field(default_factory=lambda: AuthType(AuthTypeEnum.GOOGLE))
+
+    def validate_auth_type(self) -> bool:
+        return self.auth_type.is_google()
+
+
+@dataclass(frozen=True, kw_only=True)
+class LocalAuthInfo(AuthInfo):
+    auth_type: AuthType = field(default_factory=lambda: AuthType(AuthTypeEnum.LOCAL))
+
+    def validate_auth_type(self) -> bool:
+        return self.auth_type.is_local()
+
+
+@pytest.fixture
+def google_oauth_info(time_provider: TimeProvider) -> GoogleOAuthInfo:
+    return GoogleOAuthInfo.create(time_provider=time_provider, user_id=uuid4())
+
+
+@pytest.fixture
+def local_auth_info(time_provider: TimeProvider) -> LocalAuthInfo:
+    return LocalAuthInfo.create(time_provider=time_provider, user_id=uuid4())
+
+
+@pytest.mark.unit
+class TestAuthInfo:
+    def test_is_google_auth(self, google_oauth_info: GoogleOAuthInfo) -> None:
+        assert google_oauth_info.is_google_auth()
+        assert not google_oauth_info.is_local_auth()
+
+    def test_is_local_auth(self, local_auth_info: LocalAuthInfo) -> None:
+        assert local_auth_info.is_local_auth()
+        assert not local_auth_info.is_google_auth()
+
+    def test_invalid_auth_type(self, time_provider: TimeProvider) -> None:
+        with pytest.raises(InvalidAuthTypeError):
+            GoogleOAuthInfo.create(
+                time_provider=time_provider,
+                user_id=uuid4(),
+                auth_type=AuthType(AuthTypeEnum.LOCAL),
+            )
+
+        with pytest.raises(InvalidAuthTypeError):
+            LocalAuthInfo.create(
+                time_provider=time_provider,
+                user_id=uuid4(),
+                auth_type=AuthType(AuthTypeEnum.GOOGLE),
+            )

--- a/tests/unit/domain/auth/auth_info/test_auth_info.py
+++ b/tests/unit/domain/auth/auth_info/test_auth_info.py
@@ -37,15 +37,44 @@ def local_auth_info(time_provider: TimeProvider) -> LocalAuthInfo:
 
 @pytest.mark.unit
 class TestAuthInfo:
+    """AuthInfo 및 하위 클래스(GoogleOAuthInfo, LocalAuthInfo)의 단위 테스트."""
+
     def test_is_google_auth(self, google_oauth_info: GoogleOAuthInfo) -> None:
+        """GoogleOAuthInfo 인스턴스의 is_google_auth()와 is_local_auth() 동작을 검증한다.
+
+        Given:
+            GoogleOAuthInfo 인스턴스가 준비됨.
+        When:
+            is_google_auth()와 is_local_auth() 메서드를 호출하면.
+        Then:
+            is_google_auth()는 True, is_local_auth()는 False를 반환해야 한다.
+        """
         assert google_oauth_info.is_google_auth()
         assert not google_oauth_info.is_local_auth()
 
     def test_is_local_auth(self, local_auth_info: LocalAuthInfo) -> None:
+        """LocalAuthInfo 인스턴스의 is_local_auth()와 is_google_auth() 동작을 검증한다.
+
+        Given:
+            LocalAuthInfo 인스턴스가 준비됨.
+        When:
+            is_local_auth()와 is_google_auth() 메서드를 호출하면.
+        Then:
+            is_local_auth()는 True, is_google_auth()는 False를 반환해야 한다.
+        """
         assert local_auth_info.is_local_auth()
         assert not local_auth_info.is_google_auth()
 
     def test_invalid_auth_type(self, time_provider: TimeProvider) -> None:
+        """잘못된 auth_type 주입 시 InvalidAuthTypeError 예외가 발생하는지 검증한다.
+
+        Given:
+            GoogleOAuthInfo 또는 LocalAuthInfo에 잘못된 AuthType을 명시적으로 주입함.
+        When:
+            .create() 메서드로 인스턴스를 생성하려고 시도하면.
+        Then:
+            InvalidAuthTypeError 예외가 발생해야 한다.
+        """
         with pytest.raises(InvalidAuthTypeError):
             GoogleOAuthInfo.create(
                 time_provider=time_provider,

--- a/tests/unit/domain/auth/auth_info/test_auth_info_value_objects.py
+++ b/tests/unit/domain/auth/auth_info/test_auth_info_value_objects.py
@@ -1,0 +1,28 @@
+import pytest
+
+from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum
+
+
+@pytest.fixture
+def google_auth_type() -> AuthType:
+    return AuthType(AuthTypeEnum.GOOGLE)
+
+
+@pytest.fixture
+def local_auth_type() -> AuthType:
+    return AuthType(AuthTypeEnum.LOCAL)
+
+
+@pytest.mark.unit
+class TestAuthTypeVO:
+    def test_is_google(self, google_auth_type: AuthType):
+        assert google_auth_type.is_google()
+
+    def test_is_not_google(self, local_auth_type: AuthType):
+        assert not local_auth_type.is_google()
+
+    def test_is_local(self, local_auth_type: AuthType):
+        assert local_auth_type.is_local()
+
+    def test_is_not_local(self, google_auth_type: AuthType):
+        assert not google_auth_type.is_local()

--- a/tests/unit/domain/auth/auth_info/test_auth_info_value_objects.py
+++ b/tests/unit/domain/auth/auth_info/test_auth_info_value_objects.py
@@ -15,14 +15,52 @@ def local_auth_type() -> AuthType:
 
 @pytest.mark.unit
 class TestAuthTypeVO:
+    """AuthType 값 객체(Value Object)의 동작을 검증하는 단위 테스트."""
+
     def test_is_google(self, google_auth_type: AuthType):
+        """is_google() 메서드가 Google 타입에서 True를 반환하는지 검증한다.
+
+        Given:
+            AuthTypeEnum.GOOGLE로 생성된 AuthType 인스턴스.
+        When:
+            is_google() 메서드를 호출하면.
+        Then:
+            True를 반환해야 한다.
+        """
         assert google_auth_type.is_google()
 
     def test_is_not_google(self, local_auth_type: AuthType):
+        """is_google() 메서드가 Local 타입에서 False를 반환하는지 검증한다.
+
+        Given:
+            AuthTypeEnum.LOCAL로 생성된 AuthType 인스턴스.
+        When:
+            is_google() 메서드를 호출하면.
+        Then:
+            False를 반환해야 한다.
+        """
         assert not local_auth_type.is_google()
 
     def test_is_local(self, local_auth_type: AuthType):
+        """is_local() 메서드가 Local 타입에서 True를 반환하는지 검증한다.
+
+        Given:
+            AuthTypeEnum.LOCAL로 생성된 AuthType 인스턴스.
+        When:
+            is_local() 메서드를 호출하면.
+        Then:
+            True를 반환해야 한다.
+        """
         assert local_auth_type.is_local()
 
     def test_is_not_local(self, google_auth_type: AuthType):
+        """is_local() 메서드가 Google 타입에서 False를 반환하는지 검증한다.
+
+        Given:
+            AuthTypeEnum.GOOGLE로 생성된 AuthType 인스턴스.
+        When:
+            is_local() 메서드를 호출하면.
+        Then:
+            False를 반환해야 한다.
+        """
         assert not google_auth_type.is_local()


### PR DESCRIPTION
# ✨ [Auth] 인증 타입 및 정보 관리 기능 추가

## Context
인증 모듈 내에서 `AuthType`, `AuthInfo` 등 인증 타입 식별 및 검증 책임을 캡슐화하고,  
하위 Stub 클래스(LocalAuthInfo, GoogleOAuthInfo)를 통해 `AuthInfo` 추상 계약의 테스트를 진행할 필요가 있었습니다.

## Purpose
- 인증 타입을 값 객체(VO)로 정의해 도메인 의미를 명확히 표현
- AuthInfo 추상 클래스에 인증 타입 유효성 검증 계약(validate_auth_type) 명시
- 하위 Stub 클래스에서 구체 검증 책임 구현 (테스트용 Stub)
- InvalidAuthTypeError를 통해 잘못된 타입 주입 시 예외 처리 보장
- VO, AuthInfo 단위 테스트 추가로 동작 및 계약 안정성 검증

## What to Review
- `AuthType` VO의 설계 및 기본 동작 (`is_google`, `is_local`)
- `AuthInfo` 추상 클래스의 유효성 검증 및 예외 처리 설계
- pytest 기반의 단위 테스트 및 Docstring 문서화 품질

## Summary of Changes
- `AuthTypeEnum` Enum 정의 (LOCAL, GOOGLE)
- `AuthType` VO 클래스 정의 및 판별 메서드 추가
- `AuthInfo` 추상 클래스 구현, validate_auth_type 계약 추가
- InvalidAuthTypeError 예외 클래스 정의

## Testing Guide
- `pytest` 실행 시 AuthType 및 AuthInfo 관련 테스트 모두 통과해야 함
- 특히 invalid_auth_type 테스트에서 잘못된 타입 주입 시 InvalidAuthTypeError 발생 확인

## CI Requirements
- [ ] 모든 unit test 통과

## Related Issue
- #15
