### PR TITLE
♻️ refactor: 시간 공급자(TimeProvider) 제거 및 현재 시각을 직접 전달하도록 변경

### DIFF
--- a/src/application/messaging/command/base/command.py
+++ b/src/application/messaging/command/base/command.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from typing import Any, Self
 from uuid import UUID, uuid4
 
-from shared_kernel.time.time_provider import TimeProvider
-
 
 @dataclass(frozen=True, kw_only=True)
 class Command(ABC):
@@ -13,6 +11,6 @@ class Command(ABC):
     created_at: datetime
 
     @classmethod
-    def create(cls, time_provider: TimeProvider, **kwargs: Any) -> Self:
-        kwargs.setdefault("created_at", time_provider.now())
+    def create(cls, now: datetime, **kwargs: Any) -> Self:
+        kwargs.setdefault("created_at", now)
         return cls(**kwargs)

--- a/src/application/messaging/command/user/handler/user_register_command_handler.py
+++ b/src/application/messaging/command/user/handler/user_register_command_handler.py
@@ -44,8 +44,10 @@ class UserRegisterCommandHandler(
         await self.repository.check_username_exists(username.value)
         await self.repository.check_email_exists(email.value)
 
+        now = self.time_provider.now()
+
         user = User.create(
-            time_provider=self.time_provider,
+            now=now,
             username=username,
             email=email,
             hashed_password=hashed_password,

--- a/src/domain/base/entity.py
+++ b/src/domain/base/entity.py
@@ -4,7 +4,6 @@ from typing import Any, Self
 from uuid import UUID, uuid4
 
 from domain.base.exceptions import TimestampRequiredError
-from shared_kernel.time.time_provider import TimeProvider
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -52,33 +51,31 @@ class Entity:
             raise TimestampRequiredError()
 
     @classmethod
-    def create(cls, time_provider: TimeProvider, **kwargs: Any) -> Self:
+    def create(cls, now: datetime, **kwargs: Any) -> Self:
         """현재 시각을 기준으로 엔터티를 생성합니다.
 
         Args:
-            time_provider (TimeProvider): 현재 시각을 제공하는 시간 공급자입니다.
+            now (datetime): 생성 시각.
             **kwargs: 엔터티 생성에 필요한 기타 필드 값입니다.
 
         Returns:
             Self: 생성된 엔터티 인스턴스를 반환합니다.
         """
-        now = time_provider.now()
         kwargs.setdefault("created_at", now)
         kwargs.setdefault("updated_at", now)
         return cls(**kwargs)
 
-    def update(self, time_provider: TimeProvider, **kwargs: Any) -> Self:
+    def update(self, now: datetime, **kwargs: Any) -> Self:
         """엔터티를 불변성을 유지한 채 업데이트합니다.
 
         지정된 필드를 변경하되, 새로운 인스턴스를 생성하여 기존 객체는 그대로 유지합니다.
 
         Args:
-            time_provider (TimeProvider): 현재 시각을 반환하는 시간 공급자 객체입니다.
+            now (datetime): 업데이트 시각.
             **kwargs: 수정할 필드 값들.
 
         Returns:
             Self: 수정된 엔터티 인스턴스를 새로 생성하여 반환합니다.
         """
-        now = time_provider.now()
         kwargs.setdefault("updated_at", now)
         return replace(self, **kwargs)

--- a/src/domain/user/user.py
+++ b/src/domain/user/user.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Self
 
 from domain.base.aggregate import Aggregate
 from domain.user.value_objects import Email, HashedPassword, PlainPassword, Username
 from shared_kernel.hasher.hasher import Hasher
-from shared_kernel.time.time_provider import TimeProvider
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -39,7 +39,7 @@ class User(Aggregate):
         return hasher.verify(plain_password.value, self.hashed_password.value)
 
     def change_password(
-        self, time_provider: TimeProvider, plain_password: PlainPassword, hasher: Hasher
+        self, now: datetime, plain_password: PlainPassword, hasher: Hasher
     ) -> Self:
         """비밀번호를 새 평문 비밀번호로 변경합니다.
 
@@ -47,7 +47,7 @@ class User(Aggregate):
         기존 인스턴스는 불변성을 유지하며 새로운 인스턴스를 반환합니다.
 
         Args:
-            time_provider (TimeProvider): 시간 정보를 제공하는 객체.
+            now (datetime): 비밀번호 변경 시간.
             plain_password (PlainPassword): 새 비밀번호(평문).
             hasher (Hasher): 비밀번호 해시에 사용되는 도구.
 
@@ -57,6 +57,4 @@ class User(Aggregate):
         new_hashed_password: HashedPassword = HashedPassword(
             hasher.hash(plain_password.value)
         )
-        return self.update(
-            time_provider=time_provider, hashed_password=new_hashed_password
-        )
+        return self.update(now=now, hashed_password=new_hashed_password)

--- a/tests/unit/application/messaging/command/user/handler/test_user_register_command_handler.py
+++ b/tests/unit/application/messaging/command/user/handler/test_user_register_command_handler.py
@@ -8,6 +8,7 @@ from domain.user.repository.exceptions import (
     EmailAlreadyExistsError,
     UsernameAlreadyExistsError,
 )
+from shared_kernel.time.time_provider import TimeProvider
 
 
 @pytest.fixture
@@ -22,10 +23,12 @@ def user_register_command_handler(fake_user_inmemory_repository, time_provider, 
 @pytest.mark.asyncio
 class TestUserRegisterCommand:
     async def test_successful_registration(
-        self, user_register_command_handler, time_provider
+        self,
+        user_register_command_handler: UserRegisterCommandHandler,
+        time_provider: TimeProvider,
     ):
         command = UserRegisterCommand.create(
-            time_provider=time_provider,
+            now=time_provider.now(),
             username="newuser",
             email="newuser@example.com",
             plain_password="Secret_123!",
@@ -39,7 +42,7 @@ class TestUserRegisterCommand:
         self, user_register_command_handler, time_provider, valid_user1
     ):
         command = UserRegisterCommand.create(
-            time_provider=time_provider,
+            now=time_provider.now(),
             username=valid_user1.username,
             email="unique@example.com",
             plain_password="Secret_123!",
@@ -52,7 +55,7 @@ class TestUserRegisterCommand:
         self, user_register_command_handler, time_provider, valid_user2
     ):
         command = UserRegisterCommand.create(
-            time_provider=time_provider,
+            now=time_provider.now(),
             username="uniqueuser",
             email=valid_user2.email,
             plain_password="Secret_123!",

--- a/tests/unit/domain/auth/auth_info/test_auth_info.py
+++ b/tests/unit/domain/auth/auth_info/test_auth_info.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 from uuid import uuid4
 
 import pytest
@@ -6,7 +7,6 @@ import pytest
 from domain.auth.auth_info.auth_info import AuthInfo
 from domain.auth.auth_info.exceptions import InvalidAuthTypeError
 from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum
-from shared_kernel.time.time_provider import TimeProvider
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -26,13 +26,13 @@ class LocalAuthInfo(AuthInfo):
 
 
 @pytest.fixture
-def google_oauth_info(time_provider: TimeProvider) -> GoogleOAuthInfo:
-    return GoogleOAuthInfo.create(time_provider=time_provider, user_id=uuid4())
+def google_oauth_info() -> GoogleOAuthInfo:
+    return GoogleOAuthInfo.create(now=datetime.now(), user_id=uuid4())
 
 
 @pytest.fixture
-def local_auth_info(time_provider: TimeProvider) -> LocalAuthInfo:
-    return LocalAuthInfo.create(time_provider=time_provider, user_id=uuid4())
+def local_auth_info() -> LocalAuthInfo:
+    return LocalAuthInfo.create(now=datetime.now(), user_id=uuid4())
 
 
 @pytest.mark.unit
@@ -65,7 +65,7 @@ class TestAuthInfo:
         assert local_auth_info.is_local_auth()
         assert not local_auth_info.is_google_auth()
 
-    def test_invalid_auth_type(self, time_provider: TimeProvider) -> None:
+    def test_invalid_auth_type(self) -> None:
         """잘못된 auth_type 주입 시 InvalidAuthTypeError 예외가 발생하는지 검증한다.
 
         Given:
@@ -77,14 +77,14 @@ class TestAuthInfo:
         """
         with pytest.raises(InvalidAuthTypeError):
             GoogleOAuthInfo.create(
-                time_provider=time_provider,
+                now=datetime.now(),
                 user_id=uuid4(),
                 auth_type=AuthType(AuthTypeEnum.LOCAL),
             )
 
         with pytest.raises(InvalidAuthTypeError):
             LocalAuthInfo.create(
-                time_provider=time_provider,
+                now=datetime.now(),
                 user_id=uuid4(),
                 auth_type=AuthType(AuthTypeEnum.GOOGLE),
             )

--- a/tests/unit/domain/base/test_entity.py
+++ b/tests/unit/domain/base/test_entity.py
@@ -6,15 +6,6 @@ import pytest
 
 from domain.base.entity import Entity
 from domain.base.exceptions import TimestampRequiredError
-from shared_kernel.time.time_provider import TimeProvider
-
-
-class FixedTimeProvider(TimeProvider):
-    def __init__(self, dt: datetime):
-        self._dt = dt
-
-    def now(self) -> datetime:
-        return self._dt
 
 
 class TestEntity:
@@ -37,25 +28,22 @@ class TestEntity:
     def test_create_sets_timestamps(self):
         """create()는 현재 시간을 created_at과 updated_at에 설정해야 한다."""
         dt = datetime(2025, 5, 14, 10, 0, 0)
-        tp = FixedTimeProvider(dt)
-        e = Entity.create(tp)
+        e = Entity.create(dt)
         assert e.created_at == dt
         assert e.updated_at == dt
         assert hasattr(e, "id") and e.id is not None
 
     def test_update_updates_updated_at_only(self):
         """update()는 updated_at만 현재 시간으로 갱신해야 한다."""
-        dt1 = datetime(2025, 5, 14, 10, 0, 0)
-        dt2 = datetime(2025, 5, 14, 11, 0, 0)
-        tp1 = FixedTimeProvider(dt1)
-        tp2 = FixedTimeProvider(dt2)
-        e1 = Entity.create(tp1)
-        e2 = e1.update(tp2)
+        create_dt = datetime(2025, 5, 14, 10, 0, 0)
+        update_dt = datetime(2025, 5, 14, 11, 0, 0)
+        e1 = Entity.create(create_dt)
+        e2 = e1.update(update_dt)
 
         assert e2.id == e1.id
         assert e2.created_at == e1.created_at
-        assert e2.updated_at == dt2
-        assert e1.updated_at == dt1
+        assert e2.updated_at == update_dt
+        assert e1.updated_at != e2.updated_at
 
     def test_post_init_raises_on_missing_timestamps(self):
         """created_at 또는 updated_at이 None일 경우 예외를 발생시켜야 한다."""
@@ -65,8 +53,7 @@ class TestEntity:
     def test_hash_in_set(self):
         """동일한 ID를 가진 Entity는 set에서 중복되지 않아야 한다."""
         dt = datetime(2025, 5, 14, 9, 0, 0)
-        tp = FixedTimeProvider(dt)
-        e1 = Entity.create(tp)
+        e1 = Entity.create(dt)
         e2 = replace(e1)
         s = {e1, e2}
         assert len(s) == 1

--- a/tests/unit/domain/user/test_user_entity.py
+++ b/tests/unit/domain/user/test_user_entity.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from domain.user.exceptions import (
@@ -10,13 +12,13 @@ from domain.user.exceptions import (
 )
 from domain.user.user import User
 from domain.user.value_objects import Email, HashedPassword, PlainPassword, Username
-from tests.unit.conftest import FakeHasher, FakeTimeProvider
+from tests.unit.conftest import FakeHasher
 
 
 @pytest.fixture
-def user(time_provider: FakeTimeProvider) -> User:
+def user() -> User:
     return User.create(
-        time_provider=time_provider,
+        now=datetime.now(),
         username=Username("테스트유저"),
         email=Email("test@example.com"),
         hashed_password=HashedPassword("hashed_Correct_pw_123!"),
@@ -51,11 +53,9 @@ class TestUserEntity:
         with pytest.raises(expected_exception):
             user.authenticate(PlainPassword(invalid_password), hasher)
 
-    def test_change_password_success(
-        self, user, time_provider: FakeTimeProvider, hasher: FakeHasher
-    ):
+    def test_change_password_success(self, user: User, hasher: FakeHasher):
         new_user = user.change_password(
-            time_provider=time_provider,
+            now=datetime.now(),
             plain_password=PlainPassword("NewPw123!"),
             hasher=hasher,
         )
@@ -77,14 +77,13 @@ class TestUserEntity:
     def test_change_password_invalid(
         self,
         user,
-        time_provider: FakeTimeProvider,
         invalid_password,
         expected_exception,
     ):
         hasher = FakeHasher()
         with pytest.raises(expected_exception):
             user.change_password(
-                time_provider=time_provider,
+                now=datetime.now(),
                 plain_password=PlainPassword(invalid_password),
                 hasher=hasher,
             )


### PR DESCRIPTION
# ♻️ [Auth] TimeProvider 의존 제거 및 now 주입 방식 개선

## Context
기존 코드에서는 각 도메인 메서드에서 TimeProvider를 직접 호출하여 현재 시간을 가져왔습니다.  
이로 인해 여러 메서드에서 동일한 now가 필요할 때 미세한 시간 차이가 발생하거나, 테스트에서 now를 강제 주입하기 어려운 문제가 있었습니다.

이번 PR에서는 TimeProvider 의존성을 제거하고, now를 외부에서 명시적으로 주입하는 방식으로 개선했습니다.

---

## Purpose
- TimeProvider 의존 제거
- now 값을 호출부에서 일관적으로 계산 및 주입
- 테스트에서 시간 제어를 단순화

---

## What to Review
1. Entity.update() 시그니처 변경 (now 강제 주입)
2. User 등의 도메인 메서드에서 time_provider 제거
3. 변경된 인터페이스로 인한 호출부 수정 범위

---

## Summary of Changes
- Entity.update(time_provider) → Entity.update(now)로 변경
- User.change_password 등에서 now 직접 주입하도록 변경
- 모든 관련 테스트 코드 리팩토링

---

## Testing Guide
- pytest 기준 전 테스트 통과 확인
- 테스트에서 fixed now 값 주입 방식으로 시계 제어

---

## CI Requirements
- 별도의 환경 변수/의존성 변경 없음

---

## Related Issue
Closes #18