### PR TITLE
✨ [Domain] LocalAuthInfo 애그리거트 및 단위 테스트 도입

### DIFF
--- a/src/application/messaging/command/user/handler/user_register_command_handler.py
+++ b/src/application/messaging/command/user/handler/user_register_command_handler.py
@@ -3,9 +3,10 @@ from application.messaging.command.user.user_register_command import (
     UserRegisterCommand,
     UserRegisterCommandResult,
 )
+from domain.auth.auth_info.value_objects import HashedPassword
 from domain.user.repository.user_repository import UserRepository
 from domain.user.user import User
-from domain.user.value_objects import Email, HashedPassword, PlainPassword, Username
+from domain.user.value_objects import Email, PlainPassword, Username
 from shared_kernel.hasher.hasher import Hasher
 from shared_kernel.time.time_provider import TimeProvider
 

--- a/src/domain/auth/auth_info/exceptions.py
+++ b/src/domain/auth/auth_info/exceptions.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from domain.auth.auth_info.value_objects import AuthType
 
 
@@ -15,3 +17,27 @@ class InvalidAuthTypeError(Exception):
             auth_type (AuthType): 잘못 주입된 인증 타입 값.
         """
         super().__init__(f"Invalid auth type: {auth_type.value.value}")
+
+
+class UserIdMismatchError(Exception):
+    """사용자 ID가 일치하지 않을 때 발생하는 예외.
+
+    Attributes:
+        user_id (UUID): 사용자 ID.
+    """
+
+    def __init__(self, user_id: UUID, auth_info_user_id: UUID) -> None:
+        super().__init__(f"User ID mismatch: {user_id} != {auth_info_user_id}")
+
+
+class PasswordChangeNotAllowedError(Exception):
+    """비밀번호 변경이 허용되지 않을 때 발생하는 예외.
+
+    Attributes:
+        user_auth_type (AuthType): 사용자의 인증 타입 값.
+    """
+
+    def __init__(self, user_auth_type: AuthType) -> None:
+        super().__init__(
+            f"Only local auth type can change password, User type: {user_auth_type.value.value}"
+        )

--- a/src/domain/auth/auth_info/local_auth_info.py
+++ b/src/domain/auth/auth_info/local_auth_info.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from domain.auth.auth_info.auth_info import AuthInfo
+from domain.auth.auth_info.exceptions import (
+    PasswordChangeNotAllowedError,
+    UserIdMismatchError,
+)
+from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum, HashedPassword
+from domain.user.user import User
+from shared_kernel.time.time_provider import TimeProvider
+
+
+@dataclass(frozen=True, kw_only=True)
+class LocalAuthInfo(AuthInfo):
+    """로컬 인증 정보 객체.
+
+    로컬 로그인 방식에서 비밀번호 검증, 변경, 만료 관리 책임을 갖는다.
+    user_id를 기반으로 사용자와 연결되며, 불변성을 유지한다.
+    """
+
+    auth_type: AuthType = field(default_factory=lambda: AuthType(AuthTypeEnum.LOCAL))
+    hashed_password: HashedPassword
+    password_expired_at: datetime
+
+    def validate_auth_type(self) -> bool:
+        """인증 유형이 로컬인지 확인한다.
+
+        Returns:
+            bool: LOCAL 타입이면 True, 아니면 False.
+        """
+        return self.auth_type.is_local()
+
+    def change_password(
+        self, time_provider: TimeProvider, user: User, new_password: HashedPassword
+    ) -> None:
+        """비밀번호를 변경한다.
+
+        사용자 ID와 인증 유형을 검증한 후, 새로운 비밀번호와 만료일자를 설정한다.
+
+        Args:
+            time_provider (TimeProvider): 현재 시간 제공자.
+            user (User): 비밀번호 변경 요청 사용자.
+            new_password (HashedPassword): 새롭게 설정할 해시된 비밀번호.
+
+        Raises:
+            UserIdMismatchError: user_id가 일치하지 않을 때.
+            PasswordChangeNotAllowedError: 로컬이 아닌 인증에서 비밀번호 변경을 시도할 때.
+        """
+        if user.id != self.user_id:
+            raise UserIdMismatchError(user.id, self.user_id)
+        if user.auth_type != self.auth_type:  # type: ignore[attr-defined]
+            raise PasswordChangeNotAllowedError(user.auth_type)  # type: ignore[attr-defined]
+
+        expired_at = time_provider.now() + timedelta(days=90)
+        self.update(
+            time_provider, hashed_password=new_password, password_expired_at=expired_at
+        )
+
+    def is_password_expired(self, time_provider: TimeProvider) -> bool:
+        """비밀번호가 만료되었는지 확인한다.
+
+        Args:
+            time_provider (TimeProvider): 현재 시간 제공자.
+
+        Returns:
+            bool: 만료일이 현재 시간보다 이전이면 True, 아니면 False.
+        """
+        return self.password_expired_at < time_provider.now()

--- a/src/domain/auth/auth_info/value_objects.py
+++ b/src/domain/auth/auth_info/value_objects.py
@@ -41,3 +41,14 @@ class AuthType(ValueObject[AuthTypeEnum]):
             bool: 로컬 인증이면 True, 아니면 False.
         """
         return self.value == AuthTypeEnum.LOCAL
+
+
+@dataclass(frozen=True)
+class HashedPassword(ValueObject[str]):
+    """해시 처리된 비밀번호를 표현하는 값 객체입니다.
+
+    해싱된 문자열을 저장하며, 해시 비교 등의 용도로 사용됩니다.
+    평문 비밀번호와는 다르며, 내부 값은 외부에서 직접 생성하거나 Hasher로 생성되어야 합니다.
+    """
+
+    pass

--- a/src/domain/user/user.py
+++ b/src/domain/user/user.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from typing import Self
 
+from domain.auth.auth_info.value_objects import HashedPassword
 from domain.base.aggregate import Aggregate
-from domain.user.value_objects import Email, HashedPassword, PlainPassword, Username
+from domain.user.value_objects import Email, PlainPassword, Username
 from shared_kernel.hasher.hasher import Hasher
 from shared_kernel.time.time_provider import TimeProvider
 

--- a/src/domain/user/value_objects.py
+++ b/src/domain/user/value_objects.py
@@ -83,14 +83,3 @@ class PlainPassword(ValueObject[str]):
             raise PasswordMissingNumberError()
         if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", self.value):
             raise PasswordMissingSpecialCharacterError()
-
-
-@dataclass(frozen=True)
-class HashedPassword(ValueObject[str]):
-    """해시 처리된 비밀번호를 표현하는 값 객체입니다.
-
-    해싱된 문자열을 저장하며, 해시 비교 등의 용도로 사용됩니다.
-    평문 비밀번호와는 다르며, 내부 값은 외부에서 직접 생성하거나 Hasher로 생성되어야 합니다.
-    """
-
-    pass

--- a/src/infra/persistence/sqlalchemy/postgresql/user/user_mapper.py
+++ b/src/infra/persistence/sqlalchemy/postgresql/user/user_mapper.py
@@ -1,5 +1,6 @@
+from domain.auth.auth_info.value_objects import HashedPassword
 from domain.user.user import User
-from domain.user.value_objects import Email, HashedPassword, Username
+from domain.user.value_objects import Email, Username
 from infra.persistence.base.mapper import Mapper
 from infra.persistence.sqlalchemy.postgresql.user.user_model import UserModel
 

--- a/tests/integration/infra/persistence/sqlalchemy/postgresql/user/test_sqlalchemy_pg_async_user_repository.py
+++ b/tests/integration/infra/persistence/sqlalchemy/postgresql/user/test_sqlalchemy_pg_async_user_repository.py
@@ -5,12 +5,13 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
+from domain.auth.auth_info.value_objects import HashedPassword
 from domain.user.repository.exceptions import (
     EmailAlreadyExistsError,
     UsernameAlreadyExistsError,
 )
 from domain.user.user import User
-from domain.user.value_objects import Email, HashedPassword, Username
+from domain.user.value_objects import Email, Username
 from infra.persistence.sqlalchemy.postgresql.user.user_model import UserModel
 from shared_kernel.time.time_provider import TimeProvider
 from src.infra.persistence.sqlalchemy.postgresql.user.user_mapper import UserMapper

--- a/tests/unit/domain/auth/auth_info/test_local_auth_info.py
+++ b/tests/unit/domain/auth/auth_info/test_local_auth_info.py
@@ -1,0 +1,131 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from domain.auth.auth_info.exceptions import (
+    PasswordChangeNotAllowedError,
+    UserIdMismatchError,
+)
+from domain.auth.auth_info.local_auth_info import LocalAuthInfo
+from domain.auth.auth_info.value_objects import AuthType, AuthTypeEnum, HashedPassword
+from shared_kernel.time.time_provider import TimeProvider
+
+
+@dataclass(frozen=True, kw_only=True)
+class StubUser:
+    id: UUID = field(default_factory=uuid4)
+    auth_type: AuthType = field(default_factory=lambda: AuthType(AuthTypeEnum.LOCAL))
+
+
+@pytest.fixture
+def local_user():
+    return StubUser()
+
+
+@pytest.fixture
+def google_user():
+    return StubUser(auth_type=AuthType(AuthTypeEnum.GOOGLE))
+
+
+class ExpiredTimeProvider:
+    def now(self) -> datetime:
+        return datetime.now() - timedelta(days=10)
+
+
+@pytest.fixture
+def expired_time_provider():
+    return ExpiredTimeProvider()
+
+
+@pytest.fixture
+def local_user_auth_info(time_provider: TimeProvider, local_user: StubUser):
+    return LocalAuthInfo.create(
+        time_provider, user_id=local_user.id, hashed_password=HashedPassword("password")
+    )
+
+
+@pytest.fixture
+def expired_local_user_auth_info(
+    expired_time_provider: ExpiredTimeProvider, local_user: StubUser
+):
+    return LocalAuthInfo.create(
+        expired_time_provider,
+        user_id=local_user.id,
+        hashed_password=HashedPassword("password"),
+    )
+
+
+@pytest.mark.unit
+class TestLocalAuthInfo:
+    """LocalAuthInfo 도메인 객체의 테스트."""
+
+    def test_init_success_with_local_auth_type(self, time_provider: TimeProvider):
+        local_auth_info = LocalAuthInfo.create(
+            time_provider, user_id=uuid4(), hashed_password=HashedPassword("password")
+        )
+        assert local_auth_info.auth_type == AuthType(AuthTypeEnum.LOCAL)
+
+    def test_init_raises_value_error_with_not_local_auth_type(
+        self, time_provider: TimeProvider
+    ):
+        with pytest.raises(ValueError):
+            LocalAuthInfo.create(
+                time_provider,
+                user_id=uuid4(),
+                hashed_password=HashedPassword("password"),
+                auth_type=AuthType(AuthTypeEnum.GOOGLE),
+            )
+
+    def test_is_password_expired_returns_true_if_expired(
+        self, expired_local_user_auth_info: LocalAuthInfo
+    ):
+        assert expired_local_user_auth_info.is_password_expired()
+
+    def test_is_password_expired_returns_false_if_not_expired(
+        self, local_user_auth_info: LocalAuthInfo
+    ):
+        assert not local_user_auth_info.is_password_expired()
+
+    def test_change_password_successfully_updates_password_and_expiration(
+        self,
+        time_provider: TimeProvider,
+        local_user: StubUser,
+        local_user_auth_info: LocalAuthInfo,
+    ):
+        new_password = HashedPassword("new_password")
+        updated_local_user_auth_info = local_user_auth_info.change_password(
+            time_provider, user=local_user, new_password=new_password
+        )
+        assert updated_local_user_auth_info.hashed_password == new_password
+        assert (
+            updated_local_user_auth_info.password_expired_at
+            == updated_local_user_auth_info.updated_at + timedelta(days=90)
+        )
+
+    def test_change_password_raises_user_id_mismatch_error(
+        self, time_provider: TimeProvider, local_user_auth_info: LocalAuthInfo
+    ):
+        with pytest.raises(UserIdMismatchError):
+            local_user_auth_info.change_password(
+                time_provider,
+                user=StubUser(),
+                new_password=HashedPassword("new_password"),
+            )
+
+    def test_change_password_raises_password_change_not_allowed_error(
+        self,
+        time_provider: TimeProvider,
+        local_user: StubUser,
+        local_user_auth_info: LocalAuthInfo,
+    ):
+        wrong_auth_type_user = StubUser(
+            id=local_user.id, auth_type=AuthType(AuthTypeEnum.GOOGLE)
+        )
+        with pytest.raises(PasswordChangeNotAllowedError):
+            local_user_auth_info.change_password(
+                time_provider,
+                user=wrong_auth_type_user,
+                new_password=HashedPassword("new_password"),
+            )

--- a/tests/unit/domain/auth/auth_info/test_local_auth_info.py
+++ b/tests/unit/domain/auth/auth_info/test_local_auth_info.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from domain.auth.auth_info.exceptions import (
+    InvalidAuthTypeError,
     PasswordChangeNotAllowedError,
     UserIdMismatchError,
 )
@@ -25,33 +26,18 @@ def local_user():
 
 
 @pytest.fixture
-def google_user():
-    return StubUser(auth_type=AuthType(AuthTypeEnum.GOOGLE))
-
-
-class ExpiredTimeProvider:
-    def now(self) -> datetime:
-        return datetime.now() - timedelta(days=10)
-
-
-@pytest.fixture
-def expired_time_provider():
-    return ExpiredTimeProvider()
-
-
-@pytest.fixture
-def local_user_auth_info(time_provider: TimeProvider, local_user: StubUser):
+def local_user_auth_info(local_user: StubUser):
     return LocalAuthInfo.create(
-        time_provider, user_id=local_user.id, hashed_password=HashedPassword("password")
+        now=datetime.now(),
+        user_id=local_user.id,
+        hashed_password=HashedPassword("password"),
     )
 
 
 @pytest.fixture
-def expired_local_user_auth_info(
-    expired_time_provider: ExpiredTimeProvider, local_user: StubUser
-):
+def expired_local_user_auth_info(local_user: StubUser):
     return LocalAuthInfo.create(
-        expired_time_provider,
+        now=datetime.now() - timedelta(days=100),
         user_id=local_user.id,
         hashed_password=HashedPassword("password"),
     )
@@ -61,18 +47,38 @@ def expired_local_user_auth_info(
 class TestLocalAuthInfo:
     """LocalAuthInfo 도메인 객체의 테스트."""
 
-    def test_init_success_with_local_auth_type(self, time_provider: TimeProvider):
+    def test_init_success_with_local_auth_type(self):
+        """LOCAL 타입으로 생성 시 정상적으로 초기화되는지 검증한다.
+
+        Given:
+            AuthTypeEnum.LOCAL로 생성된 LocalAuthInfo 인스턴스.
+        When:
+            create() 메서드를 호출하면.
+        Then:
+            auth_type 필드가 LOCAL로 설정되어야 한다.
+        """
         local_auth_info = LocalAuthInfo.create(
-            time_provider, user_id=uuid4(), hashed_password=HashedPassword("password")
+            now=datetime.now(),
+            user_id=uuid4(),
+            hashed_password=HashedPassword("password"),
         )
         assert local_auth_info.auth_type == AuthType(AuthTypeEnum.LOCAL)
 
     def test_init_raises_value_error_with_not_local_auth_type(
         self, time_provider: TimeProvider
     ):
-        with pytest.raises(ValueError):
+        """LOCAL 이외의 auth_type으로 생성 시 InvalidAuthTypeError가 발생하는지 검증한다.
+
+        Given:
+            AuthTypeEnum.GOOGLE로 생성 요청.
+        When:
+            LocalAuthInfo.create()를 호출하면.
+        Then:
+            InvalidAuthTypeError 예외가 발생해야 한다.
+        """
+        with pytest.raises(InvalidAuthTypeError):
             LocalAuthInfo.create(
-                time_provider,
+                now=datetime.now(),
                 user_id=uuid4(),
                 hashed_password=HashedPassword("password"),
                 auth_type=AuthType(AuthTypeEnum.GOOGLE),
@@ -81,22 +87,48 @@ class TestLocalAuthInfo:
     def test_is_password_expired_returns_true_if_expired(
         self, expired_local_user_auth_info: LocalAuthInfo
     ):
-        assert expired_local_user_auth_info.is_password_expired()
+        """만료일이 현재보다 이전이면 is_password_expired()가 True를 반환하는지 검증한다.
+
+        Given:
+            password_expired_at이 100일 전으로 설정된 LocalAuthInfo.
+        When:
+            is_password_expired()를 호출하면.
+        Then:
+            True를 반환해야 한다.
+        """
+        assert expired_local_user_auth_info.is_password_expired(datetime.now())
 
     def test_is_password_expired_returns_false_if_not_expired(
         self, local_user_auth_info: LocalAuthInfo
     ):
-        assert not local_user_auth_info.is_password_expired()
+        """만료일이 현재보다 이후이면 is_password_expired()가 False를 반환하는지 검증한다.
+
+        Given:
+            password_expired_at이 미래로 설정된 LocalAuthInfo.
+        When:
+            is_password_expired()를 호출하면.
+        Then:
+            False를 반환해야 한다.
+        """
+        assert not local_user_auth_info.is_password_expired(datetime.now())
 
     def test_change_password_successfully_updates_password_and_expiration(
         self,
-        time_provider: TimeProvider,
         local_user: StubUser,
         local_user_auth_info: LocalAuthInfo,
     ):
+        """비밀번호 변경 시 비밀번호와 만료일이 갱신되는지 검증한다.
+
+        Given:
+            현재 비밀번호가 설정된 LocalAuthInfo와 Local 사용자.
+        When:
+            change_password()를 호출해 새 비밀번호를 설정하면.
+        Then:
+            hashed_password가 갱신되고, password_expired_at이 updated_at + 90일로 설정되어야 한다.
+        """
         new_password = HashedPassword("new_password")
         updated_local_user_auth_info = local_user_auth_info.change_password(
-            time_provider, user=local_user, new_password=new_password
+            now=datetime.now(), user=local_user, new_password=new_password
         )
         assert updated_local_user_auth_info.hashed_password == new_password
         assert (
@@ -107,6 +139,15 @@ class TestLocalAuthInfo:
     def test_change_password_raises_user_id_mismatch_error(
         self, time_provider: TimeProvider, local_user_auth_info: LocalAuthInfo
     ):
+        """user_id 불일치 시 UserIdMismatchError가 발생하는지 검증한다.
+
+        Given:
+            다른 user_id를 가진 사용자.
+        When:
+            change_password()를 호출하면.
+        Then:
+            UserIdMismatchError 예외가 발생해야 한다.
+        """
         with pytest.raises(UserIdMismatchError):
             local_user_auth_info.change_password(
                 time_provider,
@@ -120,6 +161,15 @@ class TestLocalAuthInfo:
         local_user: StubUser,
         local_user_auth_info: LocalAuthInfo,
     ):
+        """auth_type이 LOCAL이 아닐 때 PasswordChangeNotAllowedError가 발생하는지 검증한다.
+
+        Given:
+            auth_type이 GOOGLE인 사용자.
+        When:
+            change_password()를 호출하면.
+        Then:
+            PasswordChangeNotAllowedError 예외가 발생해야 한다.
+        """
         wrong_auth_type_user = StubUser(
             id=local_user.id, auth_type=AuthType(AuthTypeEnum.GOOGLE)
         )

--- a/tests/unit/domain/user/test_user_entity.py
+++ b/tests/unit/domain/user/test_user_entity.py
@@ -1,5 +1,6 @@
 import pytest
 
+from domain.auth.auth_info.value_objects import HashedPassword
 from domain.user.exceptions import (
     PasswordMissingLowercaseError,
     PasswordMissingNumberError,
@@ -9,7 +10,7 @@ from domain.user.exceptions import (
     PasswordTooShortError,
 )
 from domain.user.user import User
-from domain.user.value_objects import Email, HashedPassword, PlainPassword, Username
+from domain.user.value_objects import Email, PlainPassword, Username
 from tests.unit.conftest import FakeHasher, FakeTimeProvider
 
 


### PR DESCRIPTION
# ✨ \[Domain] LocalAuthInfo 애그리거트 및 단위 테스트 도입

## Context

기존 `User` 모델은 Local 및 OAuth 인증 방식을 모두 처리하려고 하여 단일 책임 원칙을 위반하고 있었습니다. 특히 비밀번호 관리(해싱, 만료, 변경) 로직은 Local 인증에만 필요하지만, 공통 모델에서 이를 다루면서 구조가 복잡해지고 있었습니다. 이를 해결하고 향후 OAuth 확장성을 높이기 위해 Local 인증 정보를 별도 애그리거트로 분리합니다.

## Purpose

* Local 인증 책임(비밀번호 해싱, 만료, 변경)을 캡슐화한 `LocalAuthInfo` 애그리거트를 도입합니다.
* `AuthInfo` 추상 계약을 통해 서비스 계층에서 인증 방식을 유연하게 교체할 수 있도록 설계합니다.
* Local 인증 관련 예외 및 비즈니스 로직(`UserIdMismatchError`, `PasswordChangeNotAllowedError` 등)을 명확히 정의합니다.
* `pytest` 기반의 단위 테스트로 주요 동작(생성, 만료 확인, 비밀번호 변경, 예외 발생)을 검증합니다.

## What to Review

1. `LocalAuthInfo`의 책임과 설계가 단일 책임 원칙을 잘 따르는지
2. `AuthInfo` 추상 계약의 설계 및 역할이 적절한지
3. 비밀번호 변경, 만료 검증 등의 도메인 로직이 올바르게 캡슐화되었는지
4. 단위 테스트에서 Given-When-Then 패턴으로 주요 시나리오가 잘 검증되는지
5. 예외 처리(`InvalidAuthTypeError`, `UserIdMismatchError`, `PasswordChangeNotAllowedError`)의 명확성 및 적합성

## Summary of Changes

* `LocalAuthInfo` 애그리거트 및 `AuthInfo` 추상 계약 추가
* Local 인증 전용 예외 클래스 3종 정의
* `LocalAuthInfo`에서 비밀번호 만료일 기본 90일 설정, 만료 여부 체크, 비밀번호 변경 로직 구현
* `pytest` 기반 단위 테스트 클래스 추가 (생성, 만료 검증, 비밀번호 변경, 예외 발생 시나리오 커버)
* `StubUser` 테스트용 데이터 클래스 추가

## Testing Guide

* 실행: `pytest -m "unit"`
* 검증 항목:

  * `LocalAuthInfo` 생성 시 `AuthType` 검증
  * 비밀번호 만료 여부 검증
  * 비밀번호 변경 시 새 인스턴스 반환 및 만료일 갱신
  * 잘못된 사용자나 인증 타입으로 비밀번호 변경 시 예외 발생

## CI Requirements

* 별도 의존성 없음
* 기존 CI 환경에서 단위 테스트 정상 실행 가능

## Related Issue

Closes #17