### PR TITLE
Feature/google auth info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "sqlalchemy>=2.0.41",
     "pytest-cov>=6.1.1",
     "uvicorn>=0.34.2",
+    "authlib>=1.6.0",
 ]
 
 

--- a/src/domain/auth/auth_info/google/exceptions.py
+++ b/src/domain/auth/auth_info/google/exceptions.py
@@ -1,0 +1,31 @@
+"""
+Google 인증 관련 예외 정의.
+
+GoogleSubEmptyError: GoogleSub 값이 비어 있을 때 발생
+GoogleSubTooLongError: GoogleSub 값이 너무 길 때 발생
+"""
+
+
+class GoogleSubEmptyError(Exception):
+    """
+    GoogleSub 값이 비어 있을 때 발생하는 예외.
+
+    Args:
+        sub_value (str): 입력된 sub 값
+    """
+
+    def __init__(self, sub_value: str) -> None:
+        super().__init__(f"GoogleSub 값이 비어 있거나 공백입니다: '{sub_value}'")
+
+
+class GoogleSubTooLongError(Exception):
+    """
+    GoogleSub 값이 너무 길 때 발생하는 예외.
+
+    Args:
+        sub_value (str): 입력된 sub 값
+        max_length (int): 허용 최대 길이
+    """
+
+    def __init__(self, sub_value: str, max_length: int) -> None:
+        super().__init__(f"GoogleSub 값이 {max_length}자를 초과했습니다: '{sub_value}'")

--- a/src/domain/auth/auth_info/google/google_auth_info.py
+++ b/src/domain/auth/auth_info/google/google_auth_info.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+
+from domain.auth.auth_info.base.auth_info import AuthInfo
+from domain.auth.auth_info.base.value_objects import AuthType, AuthTypeEnum
+from domain.auth.auth_info.google.value_objects import GoogleSub
+
+
+@dataclass(frozen=True, kw_only=True)
+class GoogleAuthInfo(AuthInfo):
+    """
+    Google OAuth 기반 인증 정보 객체.
+
+    - Google OAuth의 sub(고유 식별자), email, 프로필 이미지 등 보유
+    - user_id를 기반으로 사용자와 연결됨
+    - 불변성을 유지하며, 인증 타입은 항상 GOOGLE
+    """
+
+    auth_type: AuthType = field(default_factory=lambda: AuthType(AuthTypeEnum.GOOGLE))
+    sub: GoogleSub
+    avatar_url: str | None
+
+    def validate_auth_type(self) -> bool:
+        """
+        인증 유형이 GOOGLE인지 확인합니다.
+
+        Returns:
+            bool: GOOGLE 타입이면 True, 아니면 False
+        """
+        return self.auth_type.is_google()

--- a/src/domain/auth/auth_info/google/value_objects.py
+++ b/src/domain/auth/auth_info/google/value_objects.py
@@ -1,0 +1,30 @@
+"""
+Google 인증 관련 값 객체 정의.
+
+GoogleSub: Google OAuth의 sub(고유 식별자) 값 객체.
+"""
+
+from dataclasses import dataclass
+
+from domain.auth.auth_info.google.exceptions import (
+    GoogleSubEmptyError,
+    GoogleSubTooLongError,
+)
+
+
+@dataclass(frozen=True)
+class GoogleSub:
+    """
+    Google OAuth의 sub(고유 식별자) 값 객체.
+
+    - 비어 있거나 공백일 수 없음
+    - 최대 128자 제한
+    """
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.value or not self.value.strip():
+            raise GoogleSubEmptyError(self.value)
+        if len(self.value) > 128:
+            raise GoogleSubTooLongError(self.value, 128)

--- a/tests/unit/domain/auth/auth_info/google/test_google_auth_info.py
+++ b/tests/unit/domain/auth/auth_info/google/test_google_auth_info.py
@@ -1,0 +1,50 @@
+"""
+GoogleAuthInfo 도메인 객체의 단위 테스트.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from domain.auth.auth_info.base.value_objects import AuthType, AuthTypeEnum
+from domain.auth.auth_info.google.google_auth_info import GoogleAuthInfo
+from domain.auth.auth_info.google.value_objects import GoogleSub
+
+
+@pytest.fixture
+def google_auth_info():
+    """
+    기본 GoogleAuthInfo 인스턴스 픽스쳐
+    """
+    return GoogleAuthInfo.create(
+        now=datetime.now(),
+        user_id=uuid4(),
+        sub=GoogleSub("sub-123"),
+        avatar_url="https://example.com/avatar.png",
+    )
+
+
+@pytest.mark.unit
+class TestGoogleAuthInfo:
+    def test_init_success_with_google_auth_type(self, google_auth_info):
+        """
+        GoogleAuthInfo가 정상적으로 초기화되는지 검증합니다.
+
+        Given: GoogleAuthInfo를 생성할 때
+        When: GOOGLE 타입, sub, avatar_url을 지정하면
+        Then: 올바르게 초기화되어야 한다.
+        """
+        assert google_auth_info.auth_type == AuthType(AuthTypeEnum.GOOGLE)
+        assert google_auth_info.sub.value == "sub-123"
+        assert google_auth_info.avatar_url == "https://example.com/avatar.png"
+
+    def test_validate_auth_type_returns_true(self, google_auth_info):
+        """
+        validate_auth_type() 동작을 검증합니다.
+
+        Given: GoogleAuthInfo 인스턴스가 있을 때
+        When: validate_auth_type()을 호출하면
+        Then: GOOGLE 타입이면 True를 반환해야 한다.
+        """
+        assert google_auth_info.validate_auth_type() is True

--- a/tests/unit/domain/auth/auth_info/google/test_value_objects.py
+++ b/tests/unit/domain/auth/auth_info/google/test_value_objects.py
@@ -1,0 +1,45 @@
+import pytest
+
+from domain.auth.auth_info.google.exceptions import (
+    GoogleSubEmptyError,
+    GoogleSubTooLongError,
+)
+from domain.auth.auth_info.google.value_objects import GoogleSub
+
+
+@pytest.mark.unit
+class TestGoogleSub:
+    def test_init_success(self):
+        """
+        정상적인 sub 값으로 GoogleSub가 생성되는지 검증합니다.
+
+        Given: 정상적인 sub 값이 주어졌을 때
+        When: GoogleSub를 생성하면
+        Then: 해당 값으로 GoogleSub 인스턴스가 생성되어야 한다.
+        """
+        sub = GoogleSub("valid-sub-123")
+        assert sub.value == "valid-sub-123"
+
+    @pytest.mark.parametrize("invalid_value", ["", "   ", None])
+    def test_init_raises_empty_error(self, invalid_value):
+        """
+        비어있거나 공백인 sub 값에 대한 예외 발생을 검증합니다.
+
+        Given: 비어있거나 공백인 sub 값이 주어졌을 때
+        When: GoogleSub를 생성하면
+        Then: GoogleSubEmptyError가 발생해야 한다.
+        """
+        with pytest.raises(GoogleSubEmptyError):
+            GoogleSub(invalid_value)
+
+    def test_init_raises_too_long_error(self):
+        """
+        128자를 초과하는 sub 값에 대한 예외 발생을 검증합니다.
+
+        Given: 128자를 초과하는 sub 값이 주어졌을 때
+        When: GoogleSub를 생성하면
+        Then: GoogleSubTooLongError가 발생해야 한다.
+        """
+        long_value = "a" * 129
+        with pytest.raises(GoogleSubTooLongError):
+            GoogleSub(long_value)

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,18 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/9d/b1e08d36899c12c8b894a44a5583ee157789f26fc4b176f8e4b6217b56e1/authlib-1.6.0.tar.gz", hash = "sha256:4367d32031b7af175ad3a323d571dc7257b7099d55978087ceae4a0d88cd3210", size = 158371, upload-time = "2025-05-23T00:21:45.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/29/587c189bbab1ccc8c86a03a5d0e13873df916380ef1be461ebe6acebf48d/authlib-1.6.0-py2.py3-none-any.whl", hash = "sha256:91685589498f79e8655e8a8947431ad6288831d643f11c55c2143ffcc738048d", size = 239981, upload-time = "2025-05-23T00:21:43.075Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -100,6 +112,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
     { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
     { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
 ]
 
 [[package]]
@@ -153,19 +187,55 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "45.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/1f/9fa001e74a1993a9cadd2333bb889e50c66327b8594ac538ab8a04f915b7/cryptography-45.0.3.tar.gz", hash = "sha256:ec21313dd335c51d7877baf2972569f40a4291b76a0ce51391523ae358d05899", size = 744738, upload-time = "2025-05-25T14:17:24.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/b2/2345dc595998caa6f68adf84e8f8b50d18e9fc4638d32b22ea8daedd4b7a/cryptography-45.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71", size = 7056239, upload-time = "2025-05-25T14:16:12.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3d/ac361649a0bfffc105e2298b720d8b862330a767dab27c06adc2ddbef96a/cryptography-45.0.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b", size = 4205541, upload-time = "2025-05-25T14:16:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3e/c02a043750494d5c445f769e9c9f67e550d65060e0bfce52d91c1362693d/cryptography-45.0.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f", size = 4433275, upload-time = "2025-05-25T14:16:16.421Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7a/9af0bfd48784e80eef3eb6fd6fde96fe706b4fc156751ce1b2b965dada70/cryptography-45.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942", size = 4209173, upload-time = "2025-05-25T14:16:18.163Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5f/d6f8753c8708912df52e67969e80ef70b8e8897306cd9eb8b98201f8c184/cryptography-45.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af3f92b1dc25621f5fad065288a44ac790c5798e986a34d393ab27d2b27fcff9", size = 3898150, upload-time = "2025-05-25T14:16:20.34Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/50/f256ab79c671fb066e47336706dc398c3b1e125f952e07d54ce82cf4011a/cryptography-45.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56", size = 4466473, upload-time = "2025-05-25T14:16:22.605Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e7/312428336bb2df0848d0768ab5a062e11a32d18139447a76dfc19ada8eed/cryptography-45.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca", size = 4211890, upload-time = "2025-05-25T14:16:24.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/53/8a130e22c1e432b3c14896ec5eb7ac01fb53c6737e1d705df7e0efb647c6/cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1", size = 4466300, upload-time = "2025-05-25T14:16:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/75/6bb6579688ef805fd16a053005fce93944cdade465fc92ef32bbc5c40681/cryptography-45.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578", size = 4332483, upload-time = "2025-05-25T14:16:28.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/11/2538f4e1ce05c6c4f81f43c1ef2bd6de7ae5e24ee284460ff6c77e42ca77/cryptography-45.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497", size = 4573714, upload-time = "2025-05-25T14:16:30.474Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/bb/e86e9cf07f73a98d84a4084e8fd420b0e82330a901d9cac8149f994c3417/cryptography-45.0.3-cp311-abi3-win32.whl", hash = "sha256:3ad69eeb92a9de9421e1f6685e85a10fbcfb75c833b42cc9bc2ba9fb00da4710", size = 2934752, upload-time = "2025-05-25T14:16:32.204Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/063bc9ddc3d1c73e959054f1fc091b79572e716ef74d6caaa56e945b4af9/cryptography-45.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490", size = 3412465, upload-time = "2025-05-25T14:16:33.888Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9b/04ead6015229a9396890d7654ee35ef630860fb42dc9ff9ec27f72157952/cryptography-45.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06", size = 7031892, upload-time = "2025-05-25T14:16:36.214Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c7/c7d05d0e133a09fc677b8a87953815c522697bdf025e5cac13ba419e7240/cryptography-45.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57", size = 4196181, upload-time = "2025-05-25T14:16:37.934Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7a/6ad3aa796b18a683657cef930a986fac0045417e2dc428fd336cfc45ba52/cryptography-45.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716", size = 4423370, upload-time = "2025-05-25T14:16:39.502Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/58/ec1461bfcb393525f597ac6a10a63938d18775b7803324072974b41a926b/cryptography-45.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8", size = 4197839, upload-time = "2025-05-25T14:16:41.322Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3d/5185b117c32ad4f40846f579369a80e710d6146c2baa8ce09d01612750db/cryptography-45.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e4253ed8f5948a3589b3caee7ad9a5bf218ffd16869c516535325fece163dcc", size = 3886324, upload-time = "2025-05-25T14:16:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/67/85/caba91a57d291a2ad46e74016d1f83ac294f08128b26e2a81e9b4f2d2555/cryptography-45.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342", size = 4450447, upload-time = "2025-05-25T14:16:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/164e3c9d559133a38279215c712b8ba38e77735d3412f37711b9f8f6f7e0/cryptography-45.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b", size = 4200576, upload-time = "2025-05-25T14:16:46.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/7a/e002d5ce624ed46dfc32abe1deff32190f3ac47ede911789ee936f5a4255/cryptography-45.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782", size = 4450308, upload-time = "2025-05-25T14:16:48.228Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ad/3fbff9c28cf09b0a71e98af57d74f3662dea4a174b12acc493de00ea3f28/cryptography-45.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65", size = 4325125, upload-time = "2025-05-25T14:16:49.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b4/51417d0cc01802304c1984d76e9592f15e4801abd44ef7ba657060520bf0/cryptography-45.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b", size = 4560038, upload-time = "2025-05-25T14:16:51.398Z" },
+    { url = "https://files.pythonhosted.org/packages/80/38/d572f6482d45789a7202fb87d052deb7a7b136bf17473ebff33536727a2c/cryptography-45.0.3-cp37-abi3-win32.whl", hash = "sha256:cb6ab89421bc90e0422aca911c69044c2912fc3debb19bb3c1bfe28ee3dff6ab", size = 2924070, upload-time = "2025-05-25T14:16:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/91/5a/61f39c0ff4443651cc64e626fa97ad3099249152039952be8f344d6b0c86/cryptography-45.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2", size = 3395005, upload-time = "2025-05-25T14:16:55.134Z" },
+]
+
+[[package]]
 name = "eisenhour-api"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "authlib" },
     { name = "bcrypt" },
     { name = "fastapi" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
-    { name = "sqlalchemy" },
     { name = "pytest-cov" },
+    { name = "sqlalchemy" },
     { name = "uvicorn" },
 ]
 
@@ -173,12 +243,13 @@ dependencies = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "authlib", specifier = ">=1.6.0" },
     { name = "bcrypt", specifier = ">=4.3.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]
@@ -293,6 +364,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# ✨ [Domain] Google 인증 정보 도메인 객체 및 값 객체, 테스트 추가

## Context

Google OAuth 기반 인증을 위한 도메인 객체와 값 객체, 예외, 그리고 단위 테스트가 필요했습니다.  
기존 인증 구조와 일관성을 유지하면서, Google 인증의 고유 식별자(sub)와 관련 예외, 테스트 커버리지를 확보하고자 했습니다.

## Purpose

- Google OAuth 인증 정보를 위한 `GoogleAuthInfo` 도메인 객체를 도입합니다.
- Google OAuth의 sub(고유 식별자) 값 객체(`GoogleSub`)와 관련 예외를 정의합니다.
- 도메인 객체와 값 객체의 정상 동작 및 예외 상황을 검증하는 단위 테스트를 추가합니다.
- Docstring, 타입, 예외 처리 등 코드 품질을 기존 도메인 구조와 일관되게 유지합니다.

## What to Review

1. **`GoogleAuthInfo` 도메인 객체 설계 및 책임 분리**
   - email, name 등은 User 엔티티로 분리, 인증 정보는 sub/프로필 이미지 등만 관리
2. **`GoogleSub` 값 객체의 유효성 검증 및 커스텀 예외 처리**
3. **테스트 코드의 시나리오, Docstring, GWT(Given/When/Then) 구조**
4. **전체 코드의 타입, 예외, 문서화 일관성**

## Summary of Changes

- `domain/auth/auth_info/google/google_auth_info.py`: Google 인증 도메인 객체 정의
- `domain/auth/auth_info/google/value_objects.py`: GoogleSub 값 객체 및 유효성 검증
- `domain/auth/auth_info/google/exceptions.py`: GoogleSub 관련 예외 정의
- `tests/unit/domain/auth/auth_info/google/test_google_auth_info.py`: 도메인 객체 단위 테스트
- `tests/unit/domain/auth/auth_info/google/test_value_objects.py`: 값 객체 단위 테스트

## Testing Guide

- `pytest tests/unit/domain/auth/auth_info/google/`
- 모든 테스트가 통과해야 하며, 테스트 목적과 시나리오가 Docstring으로 명확히 기술되어 있습니다.

## CI Requirements

- 별도의 외부 서비스 연동 없이 단위 테스트만으로 검증 가능합니다.

## Related Issue

- (필요시 이슈 번호 연결)

---

**설계 의도 및 참고**
- Google 인증 정보는 인증 고유 식별자(sub)와 프로필 이미지 등 인증에 특화된 정보만 관리합니다.
- email, name 등은 User 엔티티에서 관리하며, create 메서드는 공통 로직을 그대로 사용합니다.