### PR TITLE
🚚 chore: UserRegisterCommand 이름 변경

### DIFF
--- a/src/application/messaging/command/auth/local/handler/local_user_register_command_handler.py
+++ b/src/application/messaging/command/auth/local/handler/local_user_register_command_handler.py
@@ -1,10 +1,10 @@
 from typing import TypedDict
 
-from application.messaging.command.base.command_handler import CommandHandler
-from application.messaging.command.user.user_register_command import (
-    UserRegisterCommand,
-    UserRegisterCommandResult,
+from application.messaging.command.auth.local.local_user_register_command import (
+    LocalUserRegisterCommand,
+    LocalUserRegisterCommandResult,
 )
+from application.messaging.command.base.command_handler import CommandHandler
 from domain.auth.auth_info.base.value_objects import AuthType, AuthTypeEnum
 from domain.auth.auth_info.local.local_auth_info import LocalAuthInfo
 from domain.auth.auth_info.local.repository.local_auth_info_repository import (
@@ -18,13 +18,13 @@ from shared_kernel.hasher.hasher import Hasher
 from shared_kernel.time.time_provider import TimeProvider
 
 
-class UserRegisterRepositories(TypedDict):
+class LocalUserRegisterRepositories(TypedDict):
     user: UserRepository
     local_auth_info: LocalAuthInfoRepository
 
 
-class UserRegisterCommandHandler(
-    CommandHandler[UserRegisterCommand, UserRegisterCommandResult]
+class LocalUserRegisterCommandHandler(
+    CommandHandler[LocalUserRegisterCommand, LocalUserRegisterCommandResult]
 ):
     """사용자 등록 요청을 처리하는 커맨드 핸들러.
 
@@ -34,7 +34,7 @@ class UserRegisterCommandHandler(
 
     def __init__(
         self,
-        repositories: UserRegisterRepositories,
+        repositories: LocalUserRegisterRepositories,
         time_provider: TimeProvider,
         hasher: Hasher,
     ) -> None:
@@ -49,7 +49,9 @@ class UserRegisterCommandHandler(
         self.time_provider = time_provider
         self.hasher = hasher
 
-    async def execute(self, command: UserRegisterCommand) -> UserRegisterCommandResult:
+    async def execute(
+        self, command: LocalUserRegisterCommand
+    ) -> LocalUserRegisterCommandResult:
         username = Username(command.username)
         email = Email(command.email)
         plain_password = PlainPassword(command.plain_password)
@@ -86,7 +88,7 @@ class UserRegisterCommandHandler(
         )
         await local_auth_info_repository.save(local_auth_info)
 
-        return UserRegisterCommandResult(
+        return LocalUserRegisterCommandResult(
             id=str(user.id),
             username=user.username.value,
             email=user.email.value,

--- a/src/application/messaging/command/auth/local/local_user_register_command.py
+++ b/src/application/messaging/command/auth/local/local_user_register_command.py
@@ -5,7 +5,7 @@ from application.messaging.command.base.command_handler import CommandResult
 
 
 @dataclass(frozen=True, kw_only=True)
-class UserRegisterCommand(Command):
+class LocalUserRegisterCommand(Command):
     """사용자 등록을 위한 커맨드입니다.
 
     사용자명, 이메일, 평문 비밀번호를 포함하여 등록 요청을 전달합니다.
@@ -22,7 +22,7 @@ class UserRegisterCommand(Command):
 
 
 @dataclass(frozen=True, kw_only=True)
-class UserRegisterCommandResult(CommandResult):
+class LocalUserRegisterCommandResult(CommandResult):
     """사용자 등록 결과를 나타내는 커맨드 결과 객체입니다.
 
     등록된 사용자의 주요 정보를 포함합니다.

--- a/tests/unit/application/messaging/command/user/handler/test_user_register_command_handler.py
+++ b/tests/unit/application/messaging/command/user/handler/test_user_register_command_handler.py
@@ -1,9 +1,11 @@
 import pytest
 
-from application.messaging.command.user.handler.user_register_command_handler import (
-    UserRegisterCommandHandler,
+from application.messaging.command.auth.local.handler.local_user_register_command_handler import (
+    LocalUserRegisterCommandHandler,
 )
-from application.messaging.command.user.user_register_command import UserRegisterCommand
+from application.messaging.command.auth.local.local_user_register_command import (
+    LocalUserRegisterCommand,
+)
 from domain.auth.auth_info.base.value_objects import AuthTypeEnum
 from domain.user.repository.exceptions import (
     EmailAlreadyExistsError,
@@ -24,7 +26,7 @@ def repositories(
 
 @pytest.fixture
 def user_register_command_handler(repositories, time_provider, hasher):
-    return UserRegisterCommandHandler(
+    return LocalUserRegisterCommandHandler(
         repositories=repositories,
         time_provider=time_provider,
         hasher=hasher,
@@ -35,10 +37,10 @@ def user_register_command_handler(repositories, time_provider, hasher):
 class TestUserRegisterCommand:
     async def test_successful_registration(
         self,
-        user_register_command_handler: UserRegisterCommandHandler,
+        user_register_command_handler: LocalUserRegisterCommandHandler,
         time_provider: TimeProvider,
     ):
-        command = UserRegisterCommand.create(
+        command = LocalUserRegisterCommand.create(
             now=time_provider.now(),
             username="newuser",
             email="newuser@example.com",
@@ -53,7 +55,7 @@ class TestUserRegisterCommand:
     async def test_duplicate_username_raises_error(
         self, user_register_command_handler, time_provider, valid_user1
     ):
-        command = UserRegisterCommand.create(
+        command = LocalUserRegisterCommand.create(
             now=time_provider.now(),
             username=valid_user1.username,
             email="unique@example.com",
@@ -66,7 +68,7 @@ class TestUserRegisterCommand:
     async def test_duplicate_email_raises_error(
         self, user_register_command_handler, time_provider, valid_user2
     ):
-        command = UserRegisterCommand.create(
+        command = LocalUserRegisterCommand.create(
             now=time_provider.now(),
             username="uniqueuser",
             email=valid_user2.email,


### PR DESCRIPTION
- 책임을 명확히 하기 위해 경로를 user에서 auth/local로 변경
- 이름을 UserRegisterCommand에서 LocalUserRegisterCommand로 변경